### PR TITLE
Invert new student email updates checkbox

### DIFF
--- a/src/components/NewStudentForm/form.js
+++ b/src/components/NewStudentForm/form.js
@@ -39,6 +39,7 @@ class StudentInfoForm extends PureComponent<Props, State> {
   };
 
   state: State = Object.assign({...this.defaultFields}, {
+    emailOptIn: true,
     success: "",
     error: "",
     redirect: false
@@ -228,6 +229,7 @@ class StudentInfoForm extends PureComponent<Props, State> {
       Object.keys(this.defaultFields).map(function(key) {
         return toSubmit[key] = newState[key];
       })
+      toSubmit.emailOptOut = !this.state.emailOptIn;
       createOrUpdateProfile(toSubmit).then(function(success) {
         onSuccess();
       }).catch(function(error) {
@@ -384,8 +386,8 @@ class StudentInfoForm extends PureComponent<Props, State> {
           <h5>Email Preferences</h5>
           <FormGroup check>
             <Label check>
-              <Input onChange={this.onChange} name="emailOptOut" type="checkbox" checked={this.state.emailOptOut} />
-              <strong>Please check here if you do not wish to receive email from Mission City Swing</strong>
+              <Input onChange={this.onChange} name="emailOptIn" type="checkbox" checked={this.state.emailOptIn} />
+              <strong>Receive email updates from Mission City Swing</strong>
             </Label>
           </FormGroup>
           <br></br>


### PR DESCRIPTION
Default to having the checkbox checked with positive language of
"Receive email updates from Mission..."
Make this change such that the data remains compatible with the DB
That is, we still want to store "emailOptOut" when form is submitted

Fixes https://github.com/missmaggiemo/mcs_registration/issues/72

⚠️ Not that familiar with react so maybe there is an easier way to do this :/
Also, there's a similar checkbox on the admin form version as well - do we want to update that too?