### PR TITLE
Make checkboxes and radio buttons bigger so they are easier targets

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -43,3 +43,20 @@ div.App form {
 .required-text {
 	color: red;
 }
+
+
+.form-check {
+  margin-top: 10px;
+  padding-left: 30px;
+}
+
+.form-check-label {
+  margin-top: 0;
+  line-height: 25px;
+}
+.form-check-input {
+  margin-top: 0;
+  width: 25px;
+  height: 25px;
+  margin-left: -30px;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -9,12 +9,13 @@ import App from "./App";
 // import firebase from "firebase";
 // import { injectDatabaseForApi } from "./lib/api.js";
 
-import "./index.css";
+
 import 'bootstrap/dist/css/bootstrap.css';
 import 'react-widgets/dist/css/react-widgets.css';
 import 'react-table/react-table.css';
 import 'react-bootstrap-typeahead/css/Typeahead.css';
 import 'react-bootstrap-typeahead/css/Typeahead-bs4.css';
+import "./index.css";
 
 
 // localize for date dropdown


### PR DESCRIPTION
On the tablets it's hard to hit the small checkbox target
Swapped order of the index.css import so I could override the reactstrap
default styles

Ideal would be to be able to have separate styles for the tablet than the web
but this looks okay on the web for now

<img width="757" alt="Screenshot 2019-05-05 17 03 55" src="https://user-images.githubusercontent.com/577644/57202271-2b8d5a80-6f58-11e9-8121-a8e921118fec.png">
